### PR TITLE
Refactor: 통계 페이지 커스텀 훅 수정

### DIFF
--- a/src/pages/Statistic/hooks/useChartData.ts
+++ b/src/pages/Statistic/hooks/useChartData.ts
@@ -3,21 +3,20 @@ import { useMemo } from "react";
 import { Review } from "../../../types/review";
 import { MONTH } from "../../../constants/month"
 
-export const useChartData = (selectedYear: string, readReviews: Review[]) => {
-  
-  const getReviewsCountByMonth = (year: string, reviews: Review[]) => {
-    return MONTH.map((month) => {
-      const filterCondition = `${year}-${month}`;
-      const matchingReviews = reviews.filter(review => review.startDate.startsWith(filterCondition));
-      const monthName = month.startsWith('0') ? month.substring(1) : month;
+const getReviewsCountByMonth = (year: string, reviews: Review[]) => {
+  return MONTH.map((month) => {
+    const filterCondition = `${year}-${month}`;
+    const matchingReviews = reviews.filter(review => review.startDate.startsWith(filterCondition));
+    const monthName = month.startsWith('0') ? month.substring(1) : month;
 
-      return {
-        x: `${monthName}월`,
-        y: matchingReviews.length
-      };
-    });
-  };
-  
+    return {
+      x: `${monthName}월`,
+      y: matchingReviews.length
+    };
+  });
+};
+
+export const useChartData = (selectedYear: string, readReviews: Review[]) => {
   const reviewsCountByMonth = useMemo(() => 
     readReviews.length > 0 ? getReviewsCountByMonth(selectedYear, readReviews) : [],
     [selectedYear, readReviews]

--- a/src/pages/Statistic/hooks/useDateFilteredReviews.ts
+++ b/src/pages/Statistic/hooks/useDateFilteredReviews.ts
@@ -2,25 +2,25 @@ import { useState, useMemo } from "react";
 import { Review } from "../../../types/review";
 import { getCurrentDateInfo } from "../../../utils/dateFormat";
 
+// 읽은 책 리뷰의 날짜에서 중복 값을 제거한 나머지를 추출하는 함수
+const extractUniqueValues = (reviews: Review[], sliceFn: (date: string) => string) => 
+  [...new Set(reviews.map(review => sliceFn(review.startDate)))];
+
+// 읽은 책 리뷰의 날짜에서 가장 최근 날짜를 찾는 함수
+const findMostRecent = (values: string[], defaultValue: string) => 
+  values.length ? values.reduce((max, current) => current > max ? current : max) : defaultValue;
+
 export const useDateFilteredReviews = (readReviews: Review[]) => {
-  // 읽은 책 중에서 연도만 담은 배열
-  const startYears = useMemo(() => readReviews.map(review => review.startDate.slice(0, 4)), [readReviews]);
+  const { currentYear, currentMonth } = getCurrentDateInfo();
 
-  // 중복 연도 제거
-  const uniqueStartYears = useMemo(() => [...new Set(startYears)], [startYears]);
+  const uniqueStartYears = useMemo(() => extractUniqueValues(readReviews, date => date.slice(0, 4)), [readReviews]);
+  const uniqueStartMonths = useMemo(() => extractUniqueValues(readReviews, date => date.slice(5, 7)), [readReviews]);
 
-  // 읽은 책 중에서 가장 최근 연도
-  const recentYear = useMemo(() => {
-    if (uniqueStartYears.length === 0) {
-      return getCurrentDateInfo().currentYear;
-    }
-    return uniqueStartYears.reduce((max, current) => current > max ? current : max);
-  }, [uniqueStartYears]);
-
-  const { currentMonth } = getCurrentDateInfo();
+  const recentYear = useMemo(() => findMostRecent(uniqueStartYears, currentYear), [uniqueStartYears, currentYear]);
+  const recentMonth = useMemo(() => findMostRecent(uniqueStartMonths, currentMonth), [uniqueStartMonths, currentMonth]);
 
   const [selectedYear, setSelectedYear] = useState(recentYear);
-  const [selectedMonth, setSelectedMonth] = useState(currentMonth);
+  const [selectedMonth, setSelectedMonth] = useState(recentMonth);
 
   // 선택한 연도와 맞는 리뷰
   const matchingYearReviews = useMemo(() => 


### PR DESCRIPTION
### 작업 요약
1. 날짜 별로 리뷰를 필터링하는 커스텀 훅에서 월+년 공통으로 사용되는 함수 분리
2. 리뷰를 차트에 표시할 수 있는 형식으로 변환하는 커스텀 훅에서 데이터 처리 함수 분리

### 작업 상세 설명
**1. 날짜 별로 리뷰를 필터링하는 커스텀 훅에서 월+년 공통으로 사용되는 함수 분리**
- 기존에 리뷰의 '월' 선택 셀렉트 박스의 초기값은 '현재 날짜의 월'이었습니다.
- 사용자가 최근에 작성한 리뷰를 바로 보여주는 것이 더 나은 사용자 경험을 제공한다고 판단하여, 초기값을 '현재 날짜의 월'에서 '최근 작성한 리뷰의 월'로 수정했습니다.
- 이 과정에서 연도와 월에 필요한 로직이 공통화 되어 함수를 분리했습니다.

**2. 리뷰를 차트에 표시할 수 있는 형식으로 변환하는 커스텀 훅에서 데이터 처리 함수 분리**
- useChartData 훅에서 차트에 필요한 데이터를 처리하는 함수가 포함되어 있었습니다. (월별 리뷰 카운트)
- export되는 커스텀 훅 내부에서 꼭 필요한 로직이 아니기 때문에 외부로 분리했습니다.

### 테스트
- 새로운 초기값 설정 및 데이터 처리 함수 분리로 인해 추가된 로직이 올바르게 동작하는지 수동으로 테스트했습니다.

### 리뷰 요구사항
의견 자유롭게 공유해 주세요. 감사합니다~!